### PR TITLE
Adding export project feature

### DIFF
--- a/include/registry.h
+++ b/include/registry.h
@@ -4,6 +4,7 @@
 #include "languages.h"
 
 void register_project(const char *path, const char *name, const char *lang);
+int get_project_path(const char *name, char *dest);
 void list_projects(void);
 void check_all_status(void);
 void prune_registry(void);

--- a/include/utils.h
+++ b/include/utils.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 int run_command(const char *cmd, bool verbose);
+int zip_file(const char *src_path, const char *dest_path);
 bool write_to_file(const char *path, const char *content);
 bool write_formatted(const char *path, const char *fmt, const char *arg);
 bool write_readme(const char *path, const char *fmt, const char *name, const char *author, const char *email);

--- a/src/main.c
+++ b/src/main.c
@@ -249,8 +249,6 @@ static int handle_export(AppContext *ctx) {
     //the input of this command is 'pman export [flag] <project_name> <dest_path>'
     //where the flag tells how to export the project
 
-    fprintf(stderr, "we entered handle_export"); //debug, TOREMOVE
-
     if(ctx->argc <= 1) {
         printf(""); //add the help text to print
         return 0;
@@ -258,11 +256,38 @@ static int handle_export(AppContext *ctx) {
 
     const char *arg = ctx->argv[1];
     if(strcmp(arg, "-z") == 0 || strcmp(arg, "--zipped") == 0) {
-        printf("zipping the file"); //add the handle of zipping and exporting the file
+        
+        //reading the project name
+        char *project_name  = ctx->argv[2];
+        char src_path[256];
+        if(get_project_path(project_name, src_path) == 1) {
+            fprintf(stderr, "invalid project name");
+            return 1;
+        }
+
+        //reading the destination path:
+        char *dest_path = ctx->argv[3];
+        if(!is_safe_path(dest_path)) {
+            fprintf(stderr, "invalid destination path");
+            return 1;
+        }
+
+        char zip_dest[PATH_MAX];
+        snprintf(zip_dest, sizeof(zip_dest), "%s/%s.zip", dest_path, project_name);
+
+        if(zip_file(src_path, zip_dest) != 0) {
+            fprintf(stderr, "error during zipping the file\n");
+            return 1;
+        }
+
+        printf("%s correctly zipped and saved in: %s\n", project_name, dest_path);
+        return 0;
     }
 
     if(strcmp(arg, "-i") == 0 || strcmp(arg, "--info") == 0) {
+        //TODO
         printf("exporting the readme");
+        return 0;
     }
 }
 /* --- Dispatcher Configuration --- */

--- a/src/main.c
+++ b/src/main.c
@@ -244,6 +244,27 @@ static int handle_uninstall(AppContext *ctx) {
     return 0;
 }
 
+static int handle_export(AppContext *ctx) {
+
+    //the input of this command is 'pman export [flag] <project_name> <dest_path>'
+    //where the flag tells how to export the project
+
+    fprintf(stderr, "we entered handle_export"); //debug, TOREMOVE
+
+    if(ctx->argc <= 1) {
+        printf(""); //add the help text to print
+        return 0;
+    }
+
+    const char *arg = ctx->argv[1];
+    if(strcmp(arg, "-z") == 0 || strcmp(arg, "--zipped") == 0) {
+        printf("zipping the file"); //add the handle of zipping and exporting the file
+    }
+
+    if(strcmp(arg, "-i") == 0 || strcmp(arg, "--info") == 0) {
+        printf("exporting the readme");
+    }
+}
 /* --- Dispatcher Configuration --- */
 
 static const Command COMMANDS[] = {
@@ -251,7 +272,8 @@ static const Command COMMANDS[] = {
     {"list",   "List all registered projects",       handle_list},
     {"status", "Check Git status of all projects",   handle_status},
     {"prune",  "Remove missing projects from registry", handle_prune},
-    {"uninstall", "Uninstall pman and remove all data", handle_uninstall}
+    {"uninstall", "Uninstall pman and remove all data", handle_uninstall},
+    {"export", "Export the file project for easy sharing", handle_export}
 };
 
 static void print_usage(void) {

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 /* --- Types & Definitions --- */
 
@@ -244,38 +245,49 @@ static int handle_uninstall(AppContext *ctx) {
     return 0;
 }
 
-static int handle_export(AppContext *ctx) {
+static int handle_export(AppContext *ctx)
+{
 
-    //the input of this command is 'pman export [flag] <project_name> <dest_path>'
-    //where the flag tells how to export the project
+    // the input of this command is 'pman export [flag] <project_name> <dest_path>'
+    // where the flag tells how to export the project
 
-    if(ctx->argc <= 1) {
-        printf(""); //add the help text to print
+    if (ctx->argc <= 1 || (strcmp(ctx->argv[1], "-h") == 0 || strcmp(ctx->argv[1], "--help") == 0)) {
+        printf("pman export - Export a project\n\n");
+        printf("Usage: pman export [flag] <project_name> <dest_path>\n\n");
+        printf("Options:\n");
+        printf("  %-20s %s\n", "-h, --help", "Show this help");
+        printf("  %-20s %s\n", "-z, --zipped", "Export the project as a .zip archive");
+        printf("  %-20s %s\n", "-i, --info", "Print the project's README to stdout");
+        printf("\nDescription:\n");
+        printf("  Exports a project to the specified destination path.\n");
+        printf("  Use -z to get a compressed archive, or -i to read\n");
+        printf("  the project's README directly in the terminal.\n");
+
         return 0;
     }
 
     const char *arg = ctx->argv[1];
-    if(strcmp(arg, "-z") == 0 || strcmp(arg, "--zipped") == 0) {
-        
-        //reading the project name
-        char *project_name  = ctx->argv[2];
+    if (strcmp(arg, "-z") == 0 || strcmp(arg, "--zipped") == 0) {
+
+        // reading the project name
+        char *project_name = ctx->argv[2];
         char src_path[256];
-        if(get_project_path(project_name, src_path) == 1) {
-            fprintf(stderr, "invalid project name");
+        if (get_project_path(project_name, src_path) == 1) {
+            fprintf(stderr, "invalid project name\n");
             return 1;
         }
 
-        //reading the destination path:
+        // reading the destination path:
         char *dest_path = ctx->argv[3];
-        if(!is_safe_path(dest_path)) {
-            fprintf(stderr, "invalid destination path");
+        if (!is_safe_path(dest_path)) {
+            fprintf(stderr, "invalid destination path\n");
             return 1;
         }
 
         char zip_dest[PATH_MAX];
         snprintf(zip_dest, sizeof(zip_dest), "%s/%s.zip", dest_path, project_name);
 
-        if(zip_file(src_path, zip_dest) != 0) {
+        if (zip_file(src_path, zip_dest) != 0) {
             fprintf(stderr, "error during zipping the file\n");
             return 1;
         }
@@ -285,10 +297,41 @@ static int handle_export(AppContext *ctx) {
     }
 
     if(strcmp(arg, "-i") == 0 || strcmp(arg, "--info") == 0) {
-        //TODO
-        printf("exporting the readme");
+
+        // getting the project path
+        char *project_name = ctx->argv[2];
+        char src_dir[256];
+        
+        if (get_project_path(project_name, src_dir) == 1) {
+            fprintf(stderr, "invalid project name\n");
+            return 1;
+        }
+
+        char path[4096];
+        snprintf(path, sizeof(path), "%s/README.md", src_dir);
+        struct stat st;
+
+        if (stat(path, &st) != 0){
+            fprintf(stderr, "%s has no README\n", project_name);
+            return 1;
+        }
+
+        FILE *f = fopen(path, "r");
+
+        if (!f) {
+            fprintf(stderr, "error reading the file\n");
+        }
+
+        char buf[1024];
+        size_t n;
+        while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+            fwrite(buf, 1, n, stdout);
+        
+        fclose(f);
         return 0;
     }
+
+    return 1;
 }
 /* --- Dispatcher Configuration --- */
 

--- a/src/registry.c
+++ b/src/registry.c
@@ -57,6 +57,39 @@ void register_project(const char *path, const char *name, const char *lang) {
     free(reg_path);
 }
 
+int get_project_path(const char *name, char *dest) {
+
+    if (!name) return 1;
+
+    char *reg_path = get_registry_path();
+    if (!reg_path) return 1;
+
+    FILE *f = fopen(reg_path, "r");
+    if (!f) {
+        free(reg_path);
+        return 1;
+    }
+
+    char line[PATH_MAX + 256]; // line buffer
+    char *result = NULL;
+
+    while (fgets(line, sizeof(line), f)) {
+        // Each line format: absolute_path|name|lang|timestamp
+        char *line_path = strtok(line, "|");
+        char *line_name = strtok(NULL, "|");
+        // skip lang and timestamp
+        if (line_name && strcmp(line_name, name) == 0) {
+            // Found the project
+            result = strdup(line_path); // caller must free
+            break;
+        }
+    }
+
+    fclose(f);
+    free(reg_path);
+    strcpy(dest, result);
+}
+
 void list_projects(void) {
     char *reg_path = get_registry_path();
     if (!reg_path) return;

--- a/src/registry.c
+++ b/src/registry.c
@@ -88,6 +88,8 @@ int get_project_path(const char *name, char *dest) {
     fclose(f);
     free(reg_path);
     strcpy(dest, result);
+
+    return 0;
 }
 
 void list_projects(void) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,16 +21,12 @@ int run_command(const char *cmd, bool verbose) {
 }
 
 int zip_file(const char *src_path, const char *dest_path) {
-
     char cmd[512];
-    snprintf(cmd, sizeof(cmd), "zip -j %s %s", dest_path, src_path);
-
+    snprintf(cmd, sizeof(cmd), "zip -r %s %s", dest_path, src_path);
     int ret = system(cmd);
-
     if (ret == 0) {
         return 0;
     }
-    
     return 1;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -20,6 +20,20 @@ int run_command(const char *cmd, bool verbose) {
     return system(silent_cmd);
 }
 
+int zip_file(const char *src_path, const char *dest_path) {
+
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "zip -j %s %s", dest_path, src_path);
+
+    int ret = system(cmd);
+
+    if (ret == 0) {
+        return 0;
+    }
+    
+    return 1;
+}
+
 bool write_to_file(const char *path, const char *content) {
     FILE *f = fopen(path, "w");
     if (!f) return false;


### PR DESCRIPTION
Hi,
With this pull request im adding the `pman export` functionality
## Usage
```shell
pman export [flag] <source project name> <destination path>
``` 
The available flags are
- `-z` or `--zipped` which will zip the whole project and save the zip archive in the destination path given
- `-i` or `--info` which will print to stdout the project README if present, will be a user's job to redirect the output wherever he wants (so no `destination path` needed)
- `-h` or `--help` which will print the usage of export. This is also the default behaviour when `pman export` is called with no arguments  

## Summary
|Flag | source project name needed | destination path needed |
|-------|-------------------------------------------|-------------------------------------|
|`-z` or `--zipped` | Yes | Yes |
|`-i` or `--info` | Yes | No |
|`-h` or `--help` | No | No |

If a syntax error occurs, pman will print an error and exit.

Pman export will always exit the program right after execution is completed.
Fixes #3
